### PR TITLE
Add worker threads dynamic handling design

### DIFF
--- a/docs/389ds/design/design.md
+++ b/docs/389ds/design/design.md
@@ -3,7 +3,6 @@ title: "Design Docs"
 ---
 
 # Feature Design Documents
-
 --------------------------
 
 This page serves as a central collection point for feature design documents. Feature design documents are organized by the release where the feature is implemented.
@@ -14,27 +13,27 @@ If you are adding a new design document, use the [template](design-template.html
 
 ## Ansible DS Collection
 
-- [User Facing Design](ansible-user-facing-design.html)
-- [Backup Role](ansible-backup-role.html)
+-   [User Facing Design](ansible-user-facing-design.html)
+-   [Backup Role](ansible-backup-role.html)
 
 ## Roadmap
 
-- [Directory Server Roadmap](../FAQ/roadmap.html)
+-   [Directory Server Roadmap](../FAQ/roadmap.html)
 
 ## Feature design advice
 
-- [Configuration Migration and Upgrade](container-config-migrate.html)
+-   [Configuration Migration and Upgrade](container-config-migrate.html)
 
 ## Backend Replacement
 
-- [Phase 1 & 2 - separate BDB code & confguration](backend-redesign.html)
-- [Phase 3 - Generic DB layer](backend-redesign-phase3.html)
-- [Phase 4 - Implement LMDB](backend-redesign-phase4.html)
-- [LMDB Import Design](lmdb-import-design.html)
+-   [Phase 1 & 2 - separate BDB code & confguration](backend-redesign.html)
+-   [Phase 3 - Generic DB layer](backend-redesign-phase3.html)
+-   [Phase 4 - Implement LMDB](backend-redesign-phase4.html)
+-   [LMDB Import Design](lmdb-import-design.html)
 
 ## Ansible
 
-- [Ansible DS](ansible-ds.html)
+-   [Ansible DS](ansible-ds.html)
 
 ## 389 Directory Server 2.x
 
@@ -61,212 +60,205 @@ If you are adding a new design document, use the [template](design-template.html
 
 ## 389 Directory Server 1.4.4
 
-- [Replication Agreement Bootstrap Credentials](repl-agmt-bootstrap-design.html)
-- [Replication Changelog moved into main database](integrate-changelog-database-and-backend-database.html)
-- [Openldap to 389 Migration](openldap2ds.html)
-- [Mapping Tree Assembly Rework](mapping_tree_assembly.html)
+-   [Replication Agreement Bootstrap Credentials](repl-agmt-bootstrap-design.html)
+-   [Replication Changelog moved into main database](integrate-changelog-database-and-backend-database.html)
+-   [Openldap to 389 Migration](openldap2ds.html)
+-   [Mapping Tree Assembly Rework](mapping_tree_assembly.html)
 
 ## 389 Directory Server 1.4.3 (RHEL 8.x)
 
-- [Diskspace Monitoring](disk-monitoring.html)
-- [Database Monitoring in dsconf](dbmon-design.html)
-- [dbgen replacement in dsctl](dbgen-design.html)
-- [Search rewriters](search_rewriters.html)
-- [New Keywords in Access Log RESULT Message](access-log-new-time-stats-design.html)
-- [Reject Internal Unindexed Searches](reject-internal-unindexed-design.html)
-- [Temporary Password policy](otp-password-policy.html)
-- [Automatic virtual attribute toggle](vattr-automatic-toggle.html)
+-   [Diskspace Monitoring](disk-monitoring.html)
+-   [Database Monitoring in dsconf](dbmon-design.html)
+-   [dbgen replacement in dsctl](dbgen-design.html)
+-   [Search rewriters](search_rewriters.html)
+-   [New Keywords in Access Log RESULT Message](access-log-new-time-stats-design.html)
+-   [Reject Internal Unindexed Searches](reject-internal-unindexed-design.html)
+-   [Temporary Password policy](otp-password-policy.html)
+-   [Automatic virtual attribute toggle](vattr-automatic-toggle.html)
 
 ## 389 Directory Server 1.4.2 (RHEL 8.2)
 
-- [Healthcheck Tool](healthcheck-design.html)
-- [Protection of NSS DB password](protect-NSS-db.html)
-- [Password Upgrade On Bind](pwupgrade-on-bind.html)
-- [Filter Syntax Validation](filter-syntax-verification.html)
+-   [Healthcheck Tool](healthcheck-design.html)
+-   [Protection of NSS DB password](protect-NSS-db.html)
+-   [Password Upgrade On Bind](pwupgrade-on-bind.html)
+-   [Filter Syntax Validation](filter-syntax-verification.html)
 
 ## 389 Directory Server 1.4.1 (RHEL 8.1)
 
-- [Container Integration](docker.html)
-- [Replication Agreement Status Message Improvements](repl-agmt-status-design.html)
-- [CLI Tool and Lib389 Design Guide](cli-guide.html)
-- [Monitor Replication with CLI and Web Console Design Guide](replication-monitor-design.html)
-- [LDIF generation (dbgen) added to dsctl](dbgen-design.html)
+-   [Container Integration](docker.html)
+-   [Replication Agreement Status Message Improvements](repl-agmt-status-design.html)
+-   [CLI Tool and Lib389 Design Guide](cli-guide.html)
+-   [Monitor Replication with CLI and Web Console Design Guide](replication-monitor-design.html)
+-   [LDIF generation (dbgen) added to dsctl](dbgen-design.html)
 
 ## 389 Directory Server 1.4.0 (RHEL 8)
 
-- [Automembership Plugin Postop Modify](automember-postop-modify-design.html)
-- [New Password Poliy Syntax Checks](pwpolicy-syntax-design.html)
-- [New Python CLI Tools](dsadm-dsconf.html)
-- New Web UI (Cockpit plugin)  --> Design doc in the works...
+-   [Automembership Plugin Postop Modify](automember-postop-modify-design.html)
+-   [New Password Poliy Syntax Checks](pwpolicy-syntax-design.html)
+-   [New Python CLI Tools](dsadm-dsconf.html)
+-   New Web UI (Cockpit plugin)  --> Design doc in the works...
 
 ## 389 Directory Server 1.3.9 (RHEL 7.7)
 
-- [Automembership Plugin Postop Modify](automember-postop-modify-design.html)  (backported from 1.4.0)
+-   [Automembership Plugin Postop Modify](automember-postop-modify-design.html)  (backported from 1.4.0)
 
 ## 389 Directory Server 1.3.8 (RHEL 7.6)
 
-- Just bug fixes
+-   Just bug fixes
 
 ## 389 Directory Server 1.3.7 (RHEL 7.5)
 
-- [Replication Diff Tool](repl-diff-tool-design.html)
-- [Dynamic Certificate Mapping](certmap-ipa.html)
-- [Pblock Breakup](pblock-breakup.html)
-- [Password Policy Controls](password-controls.html)
+-   [Replication Diff Tool](repl-diff-tool-design.html)
+-   [Dynamic Certificate Mapping](certmap-ipa.html)
+-   [Pblock Breakup](pblock-breakup.html)
+-   [Password Policy Controls](password-controls.html)
 
 ## 389 Directory Server 1.3.6 (RHEL 7.4)
 
-- [Schema with Multiple Search Paths](schema-multiple-search-paths.html)
-- [New Error Log Format and Severity Level](errorlog-format-design.html)
-- [Configuration Reset](configuration-reset.html)
-- [Autotuning Memory and Threads](autotuning.html)
-- [PBKDF2](pbkdf2.html)
-- [Change to tcmalloc for Memory Allocator](tcmalloc-design.html)
+-   [Schema with Multiple Search Paths](schema-multiple-search-paths.html)
+-   [New Error Log Format and Severity Level](errorlog-format-design.html)
+-   [Configuration Reset](configuration-reset.html)
+-   [Autotuning Memory and Threads](autotuning.html)
+-   [PBKDF2](pbkdf2.html)
+-   [Change to tcmalloc for Memory Allocator](tcmalloc-design.html)
 
 ------------------------------------------------
 
 ## 389 Directory Server 1.3.5 (RHEL 7.3)
 
-- [Shadow Account Support](shadow-account-support.html)
-- [Password Expiring Control Configuration](password-expiring-design.html)
-- [Disable Instance Script Installation](disable-instance-scripts.html)
-- [Audit Logging Improvements](audit_improvement.html)
-- [Multiple Logging Backends](logging-multiple-backends.html)
-- [High Resolution Logging Timestamps](logging-high-resolution-time.html)
-- [Enhanced Account Tools for Account Policy Plugin](enhanced-account-tools.html)
-- [Allow usage of OpenLDAP libraries that do not use NSS for crypto](allow-usage-of-openldap-lib-w-openssl.html)
-- [Systemd Ask Password](systemd-ask-pass.html)
-- [Replication Convergence Improvement](repl-conv-design.html) - This feature will most likely be backported to previous versions
-- [Extended Op Plug-in Transaction Support](exop-plugin-transactions.html)
+-   [Shadow Account Support](shadow-account-support.html)
+-   [Password Expiring Control Configuration](password-expiring-design.html)
+-   [Disable Instance Script Installation](disable-instance-scripts.html)
+-   [Audit Logging Improvements](audit_improvement.html)
+-   [Multiple Logging Backends](logging-multiple-backends.html)
+-   [High Resolution Logging Timestamps](logging-high-resolution-time.html)
+-   [Enhanced Account Tools for Account Policy Plugin](enhanced-account-tools.html)
+-   [Allow usage of OpenLDAP libraries that do not use NSS for crypto](allow-usage-of-openldap-lib-w-openssl.html)
+-   [Systemd Ask Password](systemd-ask-pass.html)
+-   [Replication Convergence Improvement](repl-conv-design.html) - This feature will most likely be backported to previous versions
+-   [Extended Op Plug-in Transaction Support](exop-plugin-transactions.html)
 
 -------------------------------------------------
 
 ## 389 Directory Server 1.3.4
 
-- [Nunc Stans](nunc-stans.html)
-- [Audit Events](audit-events.html)
-- [MemberOf Plugin Scoping](memberof-scoping.html)
-- [Retro Changelog Plugin Scoping](retrocl-scoping.html)
-- [MemberOf Plugin Auto Add Objectclass](memberof-auto-add-oc.html)
+-   [Nunc Stans](nunc-stans.html)
+-   [Audit Events](audit-events.html)
+-   [MemberOf Plugin Scoping](memberof-scoping.html)
+-   [Retro Changelog Plugin Scoping](retrocl-scoping.html)
+-   [MemberOf Plugin Auto Add Objectclass](memberof-auto-add-oc.html)
 
 -------------------------------------------------
 
 ## 389 Directory Server 1.3.3
-
-- [AES Password Based Encryption](pbe.html)
-- [Referential Integrity Plugin Configuration](ri-plugin-configuration.html)
-- [MemberOf Plugin Shared Configuration](memberof-plugin-configuration.html)
-- [Replication Changelog Trimming Interval](changelog-trimming-interval.html)
-- [Dynamic Plugins](dynamic-plugins.html)
-- [Available NSS Ciphers](nss-cipher-design.html)
-- [Windows Sync Enhancements](winsync-rfe.html)
-- [Account Policy -- alwaysRecordLoginAttr](account-policy-design.html#new-attribute-alwaysrecordloginattr)
-- [Content Synchronization Plugin](content-synchronization-plugin.html)
+-   [AES Password Based Encryption](pbe.html)
+-   [Referential Integrity Plugin Configuration](ri-plugin-configuration.html)
+-   [MemberOf Plugin Shared Configuration](memberof-plugin-configuration.html)
+-   [Replication Changelog Trimming Interval](changelog-trimming-interval.html)
+-   [Dynamic Plugins](dynamic-plugins.html)
+-   [Available NSS Ciphers](nss-cipher-design.html)
+-   [Windows Sync Enhancements](winsync-rfe.html)
+-   [Account Policy -- alwaysRecordLoginAttr](account-policy-design.html#new-attribute-alwaysrecordloginattr)
+-   [Content Synchronization Plugin](content-synchronization-plugin.html)
 
 -------------------------------------------------
 
 ## 389 Directory Server 1.3.2
-
-- [POSIX Winsync SID Enhancements]( posix-winsync-sid-enhancements.html)
-- [LDAPI and Access Control]( ldapi-and-access-control.html)
-- [DNA Remote Server Setting](dna-remote-server-settings.html)
-- [Fine Grained ID List Size](fine-grained-id-list-size.html)
-- [Content Synchronization Plugin (SyncRepl)](content-synchronization-plugin.html)
-- [Plugin Internal Operation Logging](plugin-logging.html)
-- [Configuring Scope for Referential Integrity](configuring-scope-for-referential-integrity-plugin.html)
-- [Replication of Custom Schema](replication-of-custom-schema.html)
-- [Read Entry Controls](read-entry-controls.html)
-- [Intervals to compact Primary DB and Replication Changelog DB](db-compactdb-interval.html)
+-   [POSIX Winsync SID Enhancements]( posix-winsync-sid-enhancements.html)
+-   [LDAPI and Access Control]( ldapi-and-access-control.html)
+-   [DNA Remote Server Setting](dna-remote-server-settings.html)
+-   [Fine Grained ID List Size](fine-grained-id-list-size.html)
+-   [Content Synchronization Plugin (SyncRepl)](content-synchronization-plugin.html)
+-   [Plugin Internal Operation Logging](plugin-logging.html)
+-   [Configuring Scope for Referential Integrity](configuring-scope-for-referential-integrity-plugin.html)
+-   [Replication of Custom Schema](replication-of-custom-schema.html)
+-   [Read Entry Controls](read-entry-controls.html)
+-   [Intervals to compact Primary DB and Replication Changelog DB](db-compactdb-interval.html)
 
 -------------------------------------------------
 
 ## 389 Directory Server 1.3.1
-
-- [Plug-in Transaction Support](plugin-transactions.html)
-- [Normalized DN Cache](normalized-dn-cache.html)
-- [Configurable Allowed SASL Mechanisms](sasl-mechanism-configuration.html)
-- [SASL Mapping Improvements](sasl-mapping-improvements-1-dot-3-1.html)
-- [Configurable SASL Buffer](sasl-buffer.html)
-- [Replication Retry Settings](replication-retry-settings.html)
-- [Instance Script Improvements](instance-script-improvements-1-dot-3-1.html)
-- [Access Log Analyzer Improvements](logconv-improvements-1-dot-3-1.html)
-- [Replication Protocol Timeout](replication-protocol-timeout.html)
-- [Password Administrators](password-administrator.html)
-- [Referential Integrity Plugin and Replication](referint-replication-design.html)
-- [MemberOf Plugin - Skip Nested Groups](memberof-skip-nested.html)
+-   [Plug-in Transaction Support](plugin-transactions.html)
+-   [Normalized DN Cache](normalized-dn-cache.html)
+-   [Configurable Allowed SASL Mechanisms](sasl-mechanism-configuration.html)
+-   [SASL Mapping Improvements](sasl-mapping-improvements-1-dot-3-1.html)
+-   [Configurable SASL Buffer](sasl-buffer.html)
+-   [Replication Retry Settings](replication-retry-settings.html)
+-   [Instance Script Improvements](instance-script-improvements-1-dot-3-1.html)
+-   [Access Log Analyzer Improvements](logconv-improvements-1-dot-3-1.html)
+-   [Replication Protocol Timeout](replication-protocol-timeout.html)
+-   [Password Administrators](password-administrator.html)
+-   [Referential Integrity Plugin and Replication](referint-replication-design.html)
+-   [MemberOf Plugin - Skip Nested Groups](memberof-skip-nested.html)
 
 -------------------------------------------------
 
 ## 389 Administration Server 1.1.36
-
-- [Register Remote Servers using register-ds-admin.pl](console-remote-reg-design.html)
-- [Using 389 Console with Anonymous Access Disabled](../administration/console-login-and-anonymous-access.html)
-- [Security Modules, Console, and SELinux](../administration/security-module-console.html)
+-   [Register Remote Servers using register-ds-admin.pl](console-remote-reg-design.html)
+-   [Using 389 Console with Anonymous Access Disabled](../administration/console-login-and-anonymous-access.html)
+-   [Security Modules, Console, and SELinux](../administration/security-module-console.html)
 
 -------------------------------------------------
 
 ## Web-based Directory Server Management Console
-
-- [NEW Web-based Console](389-web-ui-design.html)
-- [LDAP REST API](ldap-rest-api.html)
-- ["o=dmc" Design Page](dmc-design.html)
+-   [NEW Web-based Console](389-web-ui-design.html)
+-   [LDAP REST API](ldap-rest-api.html)
+-   ["o=dmc" Design Page](dmc-design.html)
 
 -------------------------------------------------
 
 ## Older Design Documents
-
-- [64-bit Counters](64-bit-counters-design.html)
-- [Access Control and Moddn](access-control-on-trees-specified-in-moddn-operation.html)
-- [Account Policy](account-policy-design.html)
-- ["aclutil" Design](acl-utility.html)
-- [Attribute Encryption](attribute-encryption-design.html)
-- [Changelog Trimming Interval](changelog-trimming-interval.html)
-- [CLEANALLRUV Design](cleanallruv-design.html)
-- [Creation of Explicit Role Scoping](creation-of-an-explicit-scoping-for-the-roles-ticket-208.html)
-- [Database Architecture](database-architecture.html)
-- [Disable Virtual Attribute Lookups](disable-virtual-attrs.html)
-- [Diskspace Monitoring](disk-monitoring.html)
-- [DNA Plugin Remote Server Settings](dna-remote-server-settings.html)
-- [Dynamic Schema Reload](dynamically-reload-schema.html)
-- [Entry USN](entry-usn.html)
-- [Get Effective Rights](get-effective-rights-design.html)
-- [Get Effective Rights for "not present" Attributes](get-effective-rights-for-non-present-attributes.html)
-- [LDAP Transactions](ldap-transactions.html)
-- [LDAP whoami](ldapwhoami.html)
-- [Legacy Password Policy](legacy-password-policy.html)
-- [Matching Rule API](matching-rule-api.html)
-- [MemberOf Grouping Enhancements](memberof-multiple-grouping-enhancements.html)
-- [Password Migration](password-migration-design.html)
-- [Password Policy API](password-policy-api.html)
-- [Plugin Ordering](plugin-ordering.html)
-- [Plugin Design](plugins.html)
-- [Plugin Bind DN Tracking](plugin-track-bind-dn.html)
-- [POSIX Winsync SID Enhancements](posix-winsync-sid-enhancements.html)
-- [Replication Session Hooks](replication-session-hooks.html)
-- [SASL/GSSAPI/Kerberos](sasl-gssapi-kerberos-design.html)
-- [Server to Server Connections](server-to-server-conn.html)
-- [Simple Paged Results](simple-paged-results-design.html)
-- [Slapi_Task API](slapi-task-api.html)
-- [Static Group Performance](static-group-performance.html)
-- [Subtree Rename](subtree-rename.html)
-- [Syntax Validation](syntax-validation-design.html)
-- [Task Initiation](task-invocation-via-ldap.html)
-- [Task Initiation Design](task-invocation-via-ldap-design.html)
-- [Track Password Updates](track-password-update.html)
-- [Windows Sync Plugin API](windows-sync-plugin-api.html)
+-   [64-bit Counters](64-bit-counters-design.html)
+-   [Access Control and Moddn](access-control-on-trees-specified-in-moddn-operation.html)
+-   [Account Policy](account-policy-design.html)
+-   ["aclutil" Design](acl-utility.html)
+-   [Attribute Encryption](attribute-encryption-design.html)
+-   [Changelog Trimming Interval](changelog-trimming-interval.html)
+-   [CLEANALLRUV Design](cleanallruv-design.html)
+-   [Creation of Explicit Role Scoping](creation-of-an-explicit-scoping-for-the-roles-ticket-208.html)
+-   [Database Architecture](database-architecture.html)
+-   [Disable Virtual Attribute Lookups](disable-virtual-attrs.html)
+-   [Diskspace Monitoring](disk-monitoring.html)
+-   [DNA Plugin Remote Server Settings](dna-remote-server-settings.html)
+-   [Dynamic Schema Reload](dynamically-reload-schema.html)
+-   [Entry USN](entry-usn.html)
+-   [Get Effective Rights](get-effective-rights-design.html)
+-   [Get Effective Rights for "not present" Attributes](get-effective-rights-for-non-present-attributes.html)
+-   [LDAP Transactions](ldap-transactions.html)
+-   [LDAP whoami](ldapwhoami.html)
+-   [Legacy Password Policy](legacy-password-policy.html)
+-   [Matching Rule API](matching-rule-api.html)
+-   [MemberOf Grouping Enhancements](memberof-multiple-grouping-enhancements.html)
+-   [Password Migration](password-migration-design.html)
+-   [Password Policy API](password-policy-api.html)
+-   [Plugin Ordering](plugin-ordering.html)
+-   [Plugin Design](plugins.html)
+-   [Plugin Bind DN Tracking](plugin-track-bind-dn.html)
+-   [POSIX Winsync SID Enhancements](posix-winsync-sid-enhancements.html)
+-   [Replication Session Hooks](replication-session-hooks.html)
+-   [SASL/GSSAPI/Kerberos](sasl-gssapi-kerberos-design.html)
+-   [Server to Server Connections](server-to-server-conn.html)
+-   [Simple Paged Results](simple-paged-results-design.html)
+-   [Slapi_Task API](slapi-task-api.html)
+-   [Static Group Performance](static-group-performance.html)
+-   [Subtree Rename](subtree-rename.html)
+-   [Syntax Validation](syntax-validation-design.html)
+-   [Task Initiation](task-invocation-via-ldap.html)
+-   [Task Initiation Design](task-invocation-via-ldap-design.html)
+-   [Track Password Updates](track-password-update.html)
+-   [Windows Sync Plugin API](windows-sync-plugin-api.html)
 
 ---------------------------------------------
 
 ## Plugin Design Documents
-
-- [Auto Membership Plugin](automember-design.html)
-- [DNA Plugin Proposal](dna-plugin-proposal.html)
-- [DNA Plugin](dna-plugin.html)
-- [Linked Attributes Plugin](linked-attributes-design.html)
-- [Managed Entry Plugin](managed-entry-design.html)
-- [MemberOf Plugin](memberof-plugin.html)
-- [Root DN Access Control Plugin](rootdn-access-control.html)
-- [Winsync POSIX Plugin](winsync-posix.html)
+-   [Auto Membership Plugin](automember-design.html)
+-   [DNA Plugin Proposal](dna-plugin-proposal.html)
+-   [DNA Plugin](dna-plugin.html)
+-   [Linked Attributes Plugin](linked-attributes-design.html)
+-   [Managed Entry Plugin](managed-entry-design.html)
+-   [MemberOf Plugin](memberof-plugin.html)
+-   [Root DN Access Control Plugin](rootdn-access-control.html)
+-   [Winsync POSIX Plugin](winsync-posix.html)
 
 -----------------------------------------------
 
@@ -279,21 +271,24 @@ If you are adding a new design document, use the [template](design-template.html
 - [Integrate changelog into backend database](integrate-changelog-database-and-backend-database.html)
 - [Replication troubleshooting WIP](replication_troubleshooting.html)
 
+
+
 -----------------------------------------------
 
 ## Design Discussions
+-   [Token Auth](token-auth.html)
+-   [Entry State Resolution](entry-state-resolution.html)
+-   [High Contention with Entry Cache](high-contention-on-entry-cache-lock.html)
+-   [Separate Suffix for Tombstones/Conflicts](separate-conflict-and-tombstone-entry.html)
+-   [Managed Entry Plug-in Enhancement](mep-rework.html)
+-   [Managing Replication Conflicts](managing-repl-conflict-entries.html)
+-   [Logging Performance Improvement](logging-performance-improvement.html)
+-   [Dsadm and Dsconf](dsadm-dsconf.html)
+-   [Nunc Stans Workers](nunc-stans-workers.html)
+-   [Cache Redesign](cache_redesign.html)
+-   [Plugin Version 4](plugin-v4.html)
+-   [Password extensibility](password-extensibility.html)
+-   [Transactional Operations](transactional-operations.html)
+-   [PAD/PAC anchor cretaino](pad-pac-anchor-creation.html)
 
-- [Token Auth](token-auth.html)
-- [Entry State Resolution](entry-state-resolution.html)
-- [High Contention with Entry Cache](high-contention-on-entry-cache-lock.html)
-- [Separate Suffix for Tombstones/Conflicts](separate-conflict-and-tombstone-entry.html)
-- [Managed Entry Plug-in Enhancement](mep-rework.html)
-- [Managing Replication Conflicts](managing-repl-conflict-entries.html)
-- [Logging Performance Improvement](logging-performance-improvement.html)
-- [Dsadm and Dsconf](dsadm-dsconf.html)
-- [Nunc Stans Workers](nunc-stans-workers.html)
-- [Cache Redesign](cache_redesign.html)
-- [Plugin Version 4](plugin-v4.html)
-- [Password extensibility](password-extensibility.html)
-- [Transactional Operations](transactional-operations.html)
-- [PAD/PAC anchor cretaino](pad-pac-anchor-creation.html)
+

--- a/docs/389ds/design/design.md
+++ b/docs/389ds/design/design.md
@@ -3,6 +3,7 @@ title: "Design Docs"
 ---
 
 # Feature Design Documents
+
 --------------------------
 
 This page serves as a central collection point for feature design documents. Feature design documents are organized by the release where the feature is implemented.
@@ -13,27 +14,27 @@ If you are adding a new design document, use the [template](design-template.html
 
 ## Ansible DS Collection
 
--   [User Facing Design](ansible-user-facing-design.html)
--   [Backup Role](ansible-backup-role.html)
+- [User Facing Design](ansible-user-facing-design.html)
+- [Backup Role](ansible-backup-role.html)
 
 ## Roadmap
 
--   [Directory Server Roadmap](../FAQ/roadmap.html)
+- [Directory Server Roadmap](../FAQ/roadmap.html)
 
 ## Feature design advice
 
--   [Configuration Migration and Upgrade](container-config-migrate.html)
+- [Configuration Migration and Upgrade](container-config-migrate.html)
 
 ## Backend Replacement
 
--   [Phase 1 & 2 - separate BDB code & confguration](backend-redesign.html)
--   [Phase 3 - Generic DB layer](backend-redesign-phase3.html)
--   [Phase 4 - Implement LMDB](backend-redesign-phase4.html)
--   [LMDB Import Design](lmdb-import-design.html)
+- [Phase 1 & 2 - separate BDB code & confguration](backend-redesign.html)
+- [Phase 3 - Generic DB layer](backend-redesign-phase3.html)
+- [Phase 4 - Implement LMDB](backend-redesign-phase4.html)
+- [LMDB Import Design](lmdb-import-design.html)
 
 ## Ansible
 
--   [Ansible DS](ansible-ds.html)
+- [Ansible DS](ansible-ds.html)
 
 ## 389 Directory Server 2.x
 
@@ -56,208 +57,216 @@ If you are adding a new design document, use the [template](design-template.html
 -   [Support of In Chain matching rule](matching-rule-in-chain.html)
 -   [Alias Entries Plugin](alias-entries-design.html)
 -   [Account Policy Plugin Inactivity And Expiration](account-policy-inactivity-and-expiration-design.html)
+-   [Dynamic handling of the number of worker threads](worker-threads.html)
 
 ## 389 Directory Server 1.4.4
 
--   [Replication Agreement Bootstrap Credentials](repl-agmt-bootstrap-design.html)
--   [Replication Changelog moved into main database](integrate-changelog-database-and-backend-database.html)
--   [Openldap to 389 Migration](openldap2ds.html)
--   [Mapping Tree Assembly Rework](mapping_tree_assembly.html)
+- [Replication Agreement Bootstrap Credentials](repl-agmt-bootstrap-design.html)
+- [Replication Changelog moved into main database](integrate-changelog-database-and-backend-database.html)
+- [Openldap to 389 Migration](openldap2ds.html)
+- [Mapping Tree Assembly Rework](mapping_tree_assembly.html)
 
 ## 389 Directory Server 1.4.3 (RHEL 8.x)
 
--   [Diskspace Monitoring](disk-monitoring.html)
--   [Database Monitoring in dsconf](dbmon-design.html)
--   [dbgen replacement in dsctl](dbgen-design.html)
--   [Search rewriters](search_rewriters.html)
--   [New Keywords in Access Log RESULT Message](access-log-new-time-stats-design.html)
--   [Reject Internal Unindexed Searches](reject-internal-unindexed-design.html)
--   [Temporary Password policy](otp-password-policy.html)
--   [Automatic virtual attribute toggle](vattr-automatic-toggle.html)
+- [Diskspace Monitoring](disk-monitoring.html)
+- [Database Monitoring in dsconf](dbmon-design.html)
+- [dbgen replacement in dsctl](dbgen-design.html)
+- [Search rewriters](search_rewriters.html)
+- [New Keywords in Access Log RESULT Message](access-log-new-time-stats-design.html)
+- [Reject Internal Unindexed Searches](reject-internal-unindexed-design.html)
+- [Temporary Password policy](otp-password-policy.html)
+- [Automatic virtual attribute toggle](vattr-automatic-toggle.html)
 
 ## 389 Directory Server 1.4.2 (RHEL 8.2)
 
--   [Healthcheck Tool](healthcheck-design.html)
--   [Protection of NSS DB password](protect-NSS-db.html)
--   [Password Upgrade On Bind](pwupgrade-on-bind.html)
--   [Filter Syntax Validation](filter-syntax-verification.html)
+- [Healthcheck Tool](healthcheck-design.html)
+- [Protection of NSS DB password](protect-NSS-db.html)
+- [Password Upgrade On Bind](pwupgrade-on-bind.html)
+- [Filter Syntax Validation](filter-syntax-verification.html)
 
 ## 389 Directory Server 1.4.1 (RHEL 8.1)
 
--   [Container Integration](docker.html)
--   [Replication Agreement Status Message Improvements](repl-agmt-status-design.html)
--   [CLI Tool and Lib389 Design Guide](cli-guide.html)
--   [Monitor Replication with CLI and Web Console Design Guide](replication-monitor-design.html)
--   [LDIF generation (dbgen) added to dsctl](dbgen-design.html)
+- [Container Integration](docker.html)
+- [Replication Agreement Status Message Improvements](repl-agmt-status-design.html)
+- [CLI Tool and Lib389 Design Guide](cli-guide.html)
+- [Monitor Replication with CLI and Web Console Design Guide](replication-monitor-design.html)
+- [LDIF generation (dbgen) added to dsctl](dbgen-design.html)
 
 ## 389 Directory Server 1.4.0 (RHEL 8)
 
--   [Automembership Plugin Postop Modify](automember-postop-modify-design.html)
--   [New Password Poliy Syntax Checks](pwpolicy-syntax-design.html)
--   [New Python CLI Tools](dsadm-dsconf.html)
--   New Web UI (Cockpit plugin)  --> Design doc in the works...
+- [Automembership Plugin Postop Modify](automember-postop-modify-design.html)
+- [New Password Poliy Syntax Checks](pwpolicy-syntax-design.html)
+- [New Python CLI Tools](dsadm-dsconf.html)
+- New Web UI (Cockpit plugin)  --> Design doc in the works...
 
 ## 389 Directory Server 1.3.9 (RHEL 7.7)
 
--   [Automembership Plugin Postop Modify](automember-postop-modify-design.html)  (backported from 1.4.0)
+- [Automembership Plugin Postop Modify](automember-postop-modify-design.html)  (backported from 1.4.0)
 
 ## 389 Directory Server 1.3.8 (RHEL 7.6)
 
--   Just bug fixes
+- Just bug fixes
 
 ## 389 Directory Server 1.3.7 (RHEL 7.5)
 
--   [Replication Diff Tool](repl-diff-tool-design.html)
--   [Dynamic Certificate Mapping](certmap-ipa.html)
--   [Pblock Breakup](pblock-breakup.html)
--   [Password Policy Controls](password-controls.html)
+- [Replication Diff Tool](repl-diff-tool-design.html)
+- [Dynamic Certificate Mapping](certmap-ipa.html)
+- [Pblock Breakup](pblock-breakup.html)
+- [Password Policy Controls](password-controls.html)
 
 ## 389 Directory Server 1.3.6 (RHEL 7.4)
 
--   [Schema with Multiple Search Paths](schema-multiple-search-paths.html)
--   [New Error Log Format and Severity Level](errorlog-format-design.html)
--   [Configuration Reset](configuration-reset.html)
--   [Autotuning Memory and Threads](autotuning.html)
--   [PBKDF2](pbkdf2.html)
--   [Change to tcmalloc for Memory Allocator](tcmalloc-design.html)
+- [Schema with Multiple Search Paths](schema-multiple-search-paths.html)
+- [New Error Log Format and Severity Level](errorlog-format-design.html)
+- [Configuration Reset](configuration-reset.html)
+- [Autotuning Memory and Threads](autotuning.html)
+- [PBKDF2](pbkdf2.html)
+- [Change to tcmalloc for Memory Allocator](tcmalloc-design.html)
 
 ------------------------------------------------
 
 ## 389 Directory Server 1.3.5 (RHEL 7.3)
 
--   [Shadow Account Support](shadow-account-support.html)
--   [Password Expiring Control Configuration](password-expiring-design.html)
--   [Disable Instance Script Installation](disable-instance-scripts.html)
--   [Audit Logging Improvements](audit_improvement.html)
--   [Multiple Logging Backends](logging-multiple-backends.html)
--   [High Resolution Logging Timestamps](logging-high-resolution-time.html)
--   [Enhanced Account Tools for Account Policy Plugin](enhanced-account-tools.html)
--   [Allow usage of OpenLDAP libraries that do not use NSS for crypto](allow-usage-of-openldap-lib-w-openssl.html)
--   [Systemd Ask Password](systemd-ask-pass.html)
--   [Replication Convergence Improvement](repl-conv-design.html) - This feature will most likely be backported to previous versions
--   [Extended Op Plug-in Transaction Support](exop-plugin-transactions.html)
+- [Shadow Account Support](shadow-account-support.html)
+- [Password Expiring Control Configuration](password-expiring-design.html)
+- [Disable Instance Script Installation](disable-instance-scripts.html)
+- [Audit Logging Improvements](audit_improvement.html)
+- [Multiple Logging Backends](logging-multiple-backends.html)
+- [High Resolution Logging Timestamps](logging-high-resolution-time.html)
+- [Enhanced Account Tools for Account Policy Plugin](enhanced-account-tools.html)
+- [Allow usage of OpenLDAP libraries that do not use NSS for crypto](allow-usage-of-openldap-lib-w-openssl.html)
+- [Systemd Ask Password](systemd-ask-pass.html)
+- [Replication Convergence Improvement](repl-conv-design.html) - This feature will most likely be backported to previous versions
+- [Extended Op Plug-in Transaction Support](exop-plugin-transactions.html)
 
 -------------------------------------------------
 
 ## 389 Directory Server 1.3.4
 
--   [Nunc Stans](nunc-stans.html)
--   [Audit Events](audit-events.html)
--   [MemberOf Plugin Scoping](memberof-scoping.html)
--   [Retro Changelog Plugin Scoping](retrocl-scoping.html)
--   [MemberOf Plugin Auto Add Objectclass](memberof-auto-add-oc.html)
+- [Nunc Stans](nunc-stans.html)
+- [Audit Events](audit-events.html)
+- [MemberOf Plugin Scoping](memberof-scoping.html)
+- [Retro Changelog Plugin Scoping](retrocl-scoping.html)
+- [MemberOf Plugin Auto Add Objectclass](memberof-auto-add-oc.html)
 
 -------------------------------------------------
 
 ## 389 Directory Server 1.3.3
--   [AES Password Based Encryption](pbe.html)
--   [Referential Integrity Plugin Configuration](ri-plugin-configuration.html)
--   [MemberOf Plugin Shared Configuration](memberof-plugin-configuration.html)
--   [Replication Changelog Trimming Interval](changelog-trimming-interval.html)
--   [Dynamic Plugins](dynamic-plugins.html)
--   [Available NSS Ciphers](nss-cipher-design.html)
--   [Windows Sync Enhancements](winsync-rfe.html)
--   [Account Policy -- alwaysRecordLoginAttr](account-policy-design.html#new-attribute-alwaysrecordloginattr)
--   [Content Synchronization Plugin](content-synchronization-plugin.html)
+
+- [AES Password Based Encryption](pbe.html)
+- [Referential Integrity Plugin Configuration](ri-plugin-configuration.html)
+- [MemberOf Plugin Shared Configuration](memberof-plugin-configuration.html)
+- [Replication Changelog Trimming Interval](changelog-trimming-interval.html)
+- [Dynamic Plugins](dynamic-plugins.html)
+- [Available NSS Ciphers](nss-cipher-design.html)
+- [Windows Sync Enhancements](winsync-rfe.html)
+- [Account Policy -- alwaysRecordLoginAttr](account-policy-design.html#new-attribute-alwaysrecordloginattr)
+- [Content Synchronization Plugin](content-synchronization-plugin.html)
 
 -------------------------------------------------
 
 ## 389 Directory Server 1.3.2
--   [POSIX Winsync SID Enhancements]( posix-winsync-sid-enhancements.html)
--   [LDAPI and Access Control]( ldapi-and-access-control.html)
--   [DNA Remote Server Setting](dna-remote-server-settings.html)
--   [Fine Grained ID List Size](fine-grained-id-list-size.html)
--   [Content Synchronization Plugin (SyncRepl)](content-synchronization-plugin.html)
--   [Plugin Internal Operation Logging](plugin-logging.html)
--   [Configuring Scope for Referential Integrity](configuring-scope-for-referential-integrity-plugin.html)
--   [Replication of Custom Schema](replication-of-custom-schema.html)
--   [Read Entry Controls](read-entry-controls.html)
--   [Intervals to compact Primary DB and Replication Changelog DB](db-compactdb-interval.html)
+
+- [POSIX Winsync SID Enhancements]( posix-winsync-sid-enhancements.html)
+- [LDAPI and Access Control]( ldapi-and-access-control.html)
+- [DNA Remote Server Setting](dna-remote-server-settings.html)
+- [Fine Grained ID List Size](fine-grained-id-list-size.html)
+- [Content Synchronization Plugin (SyncRepl)](content-synchronization-plugin.html)
+- [Plugin Internal Operation Logging](plugin-logging.html)
+- [Configuring Scope for Referential Integrity](configuring-scope-for-referential-integrity-plugin.html)
+- [Replication of Custom Schema](replication-of-custom-schema.html)
+- [Read Entry Controls](read-entry-controls.html)
+- [Intervals to compact Primary DB and Replication Changelog DB](db-compactdb-interval.html)
 
 -------------------------------------------------
 
 ## 389 Directory Server 1.3.1
--   [Plug-in Transaction Support](plugin-transactions.html)
--   [Normalized DN Cache](normalized-dn-cache.html)
--   [Configurable Allowed SASL Mechanisms](sasl-mechanism-configuration.html)
--   [SASL Mapping Improvements](sasl-mapping-improvements-1-dot-3-1.html)
--   [Configurable SASL Buffer](sasl-buffer.html)
--   [Replication Retry Settings](replication-retry-settings.html)
--   [Instance Script Improvements](instance-script-improvements-1-dot-3-1.html)
--   [Access Log Analyzer Improvements](logconv-improvements-1-dot-3-1.html)
--   [Replication Protocol Timeout](replication-protocol-timeout.html)
--   [Password Administrators](password-administrator.html)
--   [Referential Integrity Plugin and Replication](referint-replication-design.html)
--   [MemberOf Plugin - Skip Nested Groups](memberof-skip-nested.html)
+
+- [Plug-in Transaction Support](plugin-transactions.html)
+- [Normalized DN Cache](normalized-dn-cache.html)
+- [Configurable Allowed SASL Mechanisms](sasl-mechanism-configuration.html)
+- [SASL Mapping Improvements](sasl-mapping-improvements-1-dot-3-1.html)
+- [Configurable SASL Buffer](sasl-buffer.html)
+- [Replication Retry Settings](replication-retry-settings.html)
+- [Instance Script Improvements](instance-script-improvements-1-dot-3-1.html)
+- [Access Log Analyzer Improvements](logconv-improvements-1-dot-3-1.html)
+- [Replication Protocol Timeout](replication-protocol-timeout.html)
+- [Password Administrators](password-administrator.html)
+- [Referential Integrity Plugin and Replication](referint-replication-design.html)
+- [MemberOf Plugin - Skip Nested Groups](memberof-skip-nested.html)
 
 -------------------------------------------------
 
 ## 389 Administration Server 1.1.36
--   [Register Remote Servers using register-ds-admin.pl](console-remote-reg-design.html)
--   [Using 389 Console with Anonymous Access Disabled](../administration/console-login-and-anonymous-access.html)
--   [Security Modules, Console, and SELinux](../administration/security-module-console.html)
+
+- [Register Remote Servers using register-ds-admin.pl](console-remote-reg-design.html)
+- [Using 389 Console with Anonymous Access Disabled](../administration/console-login-and-anonymous-access.html)
+- [Security Modules, Console, and SELinux](../administration/security-module-console.html)
 
 -------------------------------------------------
 
 ## Web-based Directory Server Management Console
--   [NEW Web-based Console](389-web-ui-design.html)
--   [LDAP REST API](ldap-rest-api.html)
--   ["o=dmc" Design Page](dmc-design.html)
+
+- [NEW Web-based Console](389-web-ui-design.html)
+- [LDAP REST API](ldap-rest-api.html)
+- ["o=dmc" Design Page](dmc-design.html)
 
 -------------------------------------------------
 
 ## Older Design Documents
--   [64-bit Counters](64-bit-counters-design.html)
--   [Access Control and Moddn](access-control-on-trees-specified-in-moddn-operation.html)
--   [Account Policy](account-policy-design.html)
--   ["aclutil" Design](acl-utility.html)
--   [Attribute Encryption](attribute-encryption-design.html)
--   [Changelog Trimming Interval](changelog-trimming-interval.html)
--   [CLEANALLRUV Design](cleanallruv-design.html)
--   [Creation of Explicit Role Scoping](creation-of-an-explicit-scoping-for-the-roles-ticket-208.html)
--   [Database Architecture](database-architecture.html)
--   [Disable Virtual Attribute Lookups](disable-virtual-attrs.html)
--   [Diskspace Monitoring](disk-monitoring.html)
--   [DNA Plugin Remote Server Settings](dna-remote-server-settings.html)
--   [Dynamic Schema Reload](dynamically-reload-schema.html)
--   [Entry USN](entry-usn.html)
--   [Get Effective Rights](get-effective-rights-design.html)
--   [Get Effective Rights for "not present" Attributes](get-effective-rights-for-non-present-attributes.html)
--   [LDAP Transactions](ldap-transactions.html)
--   [LDAP whoami](ldapwhoami.html)
--   [Legacy Password Policy](legacy-password-policy.html)
--   [Matching Rule API](matching-rule-api.html)
--   [MemberOf Grouping Enhancements](memberof-multiple-grouping-enhancements.html)
--   [Password Migration](password-migration-design.html)
--   [Password Policy API](password-policy-api.html)
--   [Plugin Ordering](plugin-ordering.html)
--   [Plugin Design](plugins.html)
--   [Plugin Bind DN Tracking](plugin-track-bind-dn.html)
--   [POSIX Winsync SID Enhancements](posix-winsync-sid-enhancements.html)
--   [Replication Session Hooks](replication-session-hooks.html)
--   [SASL/GSSAPI/Kerberos](sasl-gssapi-kerberos-design.html)
--   [Server to Server Connections](server-to-server-conn.html)
--   [Simple Paged Results](simple-paged-results-design.html)
--   [Slapi_Task API](slapi-task-api.html)
--   [Static Group Performance](static-group-performance.html)
--   [Subtree Rename](subtree-rename.html)
--   [Syntax Validation](syntax-validation-design.html)
--   [Task Initiation](task-invocation-via-ldap.html)
--   [Task Initiation Design](task-invocation-via-ldap-design.html)
--   [Track Password Updates](track-password-update.html)
--   [Windows Sync Plugin API](windows-sync-plugin-api.html)
+
+- [64-bit Counters](64-bit-counters-design.html)
+- [Access Control and Moddn](access-control-on-trees-specified-in-moddn-operation.html)
+- [Account Policy](account-policy-design.html)
+- ["aclutil" Design](acl-utility.html)
+- [Attribute Encryption](attribute-encryption-design.html)
+- [Changelog Trimming Interval](changelog-trimming-interval.html)
+- [CLEANALLRUV Design](cleanallruv-design.html)
+- [Creation of Explicit Role Scoping](creation-of-an-explicit-scoping-for-the-roles-ticket-208.html)
+- [Database Architecture](database-architecture.html)
+- [Disable Virtual Attribute Lookups](disable-virtual-attrs.html)
+- [Diskspace Monitoring](disk-monitoring.html)
+- [DNA Plugin Remote Server Settings](dna-remote-server-settings.html)
+- [Dynamic Schema Reload](dynamically-reload-schema.html)
+- [Entry USN](entry-usn.html)
+- [Get Effective Rights](get-effective-rights-design.html)
+- [Get Effective Rights for "not present" Attributes](get-effective-rights-for-non-present-attributes.html)
+- [LDAP Transactions](ldap-transactions.html)
+- [LDAP whoami](ldapwhoami.html)
+- [Legacy Password Policy](legacy-password-policy.html)
+- [Matching Rule API](matching-rule-api.html)
+- [MemberOf Grouping Enhancements](memberof-multiple-grouping-enhancements.html)
+- [Password Migration](password-migration-design.html)
+- [Password Policy API](password-policy-api.html)
+- [Plugin Ordering](plugin-ordering.html)
+- [Plugin Design](plugins.html)
+- [Plugin Bind DN Tracking](plugin-track-bind-dn.html)
+- [POSIX Winsync SID Enhancements](posix-winsync-sid-enhancements.html)
+- [Replication Session Hooks](replication-session-hooks.html)
+- [SASL/GSSAPI/Kerberos](sasl-gssapi-kerberos-design.html)
+- [Server to Server Connections](server-to-server-conn.html)
+- [Simple Paged Results](simple-paged-results-design.html)
+- [Slapi_Task API](slapi-task-api.html)
+- [Static Group Performance](static-group-performance.html)
+- [Subtree Rename](subtree-rename.html)
+- [Syntax Validation](syntax-validation-design.html)
+- [Task Initiation](task-invocation-via-ldap.html)
+- [Task Initiation Design](task-invocation-via-ldap-design.html)
+- [Track Password Updates](track-password-update.html)
+- [Windows Sync Plugin API](windows-sync-plugin-api.html)
 
 ---------------------------------------------
 
 ## Plugin Design Documents
--   [Auto Membership Plugin](automember-design.html)
--   [DNA Plugin Proposal](dna-plugin-proposal.html)
--   [DNA Plugin](dna-plugin.html)
--   [Linked Attributes Plugin](linked-attributes-design.html)
--   [Managed Entry Plugin](managed-entry-design.html)
--   [MemberOf Plugin](memberof-plugin.html)
--   [Root DN Access Control Plugin](rootdn-access-control.html)
--   [Winsync POSIX Plugin](winsync-posix.html)
+
+- [Auto Membership Plugin](automember-design.html)
+- [DNA Plugin Proposal](dna-plugin-proposal.html)
+- [DNA Plugin](dna-plugin.html)
+- [Linked Attributes Plugin](linked-attributes-design.html)
+- [Managed Entry Plugin](managed-entry-design.html)
+- [MemberOf Plugin](memberof-plugin.html)
+- [Root DN Access Control Plugin](rootdn-access-control.html)
+- [Winsync POSIX Plugin](winsync-posix.html)
 
 -----------------------------------------------
 
@@ -270,24 +279,21 @@ If you are adding a new design document, use the [template](design-template.html
 - [Integrate changelog into backend database](integrate-changelog-database-and-backend-database.html)
 - [Replication troubleshooting WIP](replication_troubleshooting.html)
 
-
-
 -----------------------------------------------
 
 ## Design Discussions
--   [Token Auth](token-auth.html)
--   [Entry State Resolution](entry-state-resolution.html)
--   [High Contention with Entry Cache](high-contention-on-entry-cache-lock.html)
--   [Separate Suffix for Tombstones/Conflicts](separate-conflict-and-tombstone-entry.html)
--   [Managed Entry Plug-in Enhancement](mep-rework.html)
--   [Managing Replication Conflicts](managing-repl-conflict-entries.html)
--   [Logging Performance Improvement](logging-performance-improvement.html)
--   [Dsadm and Dsconf](dsadm-dsconf.html)
--   [Nunc Stans Workers](nunc-stans-workers.html)
--   [Cache Redesign](cache_redesign.html)
--   [Plugin Version 4](plugin-v4.html)
--   [Password extensibility](password-extensibility.html)
--   [Transactional Operations](transactional-operations.html)
--   [PAD/PAC anchor cretaino](pad-pac-anchor-creation.html)
 
-
+- [Token Auth](token-auth.html)
+- [Entry State Resolution](entry-state-resolution.html)
+- [High Contention with Entry Cache](high-contention-on-entry-cache-lock.html)
+- [Separate Suffix for Tombstones/Conflicts](separate-conflict-and-tombstone-entry.html)
+- [Managed Entry Plug-in Enhancement](mep-rework.html)
+- [Managing Replication Conflicts](managing-repl-conflict-entries.html)
+- [Logging Performance Improvement](logging-performance-improvement.html)
+- [Dsadm and Dsconf](dsadm-dsconf.html)
+- [Nunc Stans Workers](nunc-stans-workers.html)
+- [Cache Redesign](cache_redesign.html)
+- [Plugin Version 4](plugin-v4.html)
+- [Password extensibility](password-extensibility.html)
+- [Transactional Operations](transactional-operations.html)
+- [PAD/PAC anchor cretaino](pad-pac-anchor-creation.html)

--- a/docs/389ds/design/worker-threads.md
+++ b/docs/389ds/design/worker-threads.md
@@ -1,0 +1,310 @@
+---
+title: "Worker Threads dynamic management"
+---
+
+# Worker Threads dynamic management - Software Design Specification
+
+--------------------------------------------------------------------
+
+{% include toc.md %}
+
+Introduction
+------------
+
+The current worker threads (that process the ldap operations) implementation has several flaws:
+    - need to restart the server after changing the configured number of threads
+    - contention at the global mutex and condition variable level
+    - configuring too few or too many worker threads noticeably impact the performance
+
+## Current implementation synopsys
+
+--------------------
+
+There is a global mutex and a global condition variable and a global queue
+
+- listener threads push data in in the global queue and wake up the worker threads
+- worker threads loops waiting on the global condition variable for new work
+  then process it.
+- to speed up the queueing and limit the alloc/free a stack of list element is used
+
+## New implementation
+
+--------------------
+
+### Stacked data
+
+  In current implementation there are two stacks to handle:
+  - the work queue element
+  - the operation struct
+  and avoid freeing/allocing them every time. 
+  I proposed to:
+  - keep the operation in the thread context. (Anyway a thread only works on a single operation at a time)
+  - keep a free list of element for the waiting_job list. (That cannot be more than the maximum of connections in the queue so in the worse case the free list will 3*8*64K (i.e around 3 Mb) but I wonder if we should not reduce this list size and let the listening threads sleep for a few ms if there are no more items. ( Anyway if the sleep delay is smaller than the time needed to flush the waiting job queue, no time is wasted.)
+
+### Overload warning (flow control)
+
+A warning is logged if
+- The warning has not been logged since some delay (1 minute)
+- The waiting job queue size gets higher than a threshold (100*number of worker threads)
+
+### Producters/consumers algorithm
+
+There is still a global mutex and also three lists:
+
+- waiting_threads
+- busy_threads
+- waiting_jobs
+  Access to these lists are protected by the global mutex lock
+
+When pushing new job the listener threads:
+
+- Get global mutex
+- Loop forever:
+  - if waiting_threads is not empty:
+    - Select the first waiting thread
+    - Move the thread out of waiting_threads list into the busy_threads list
+    - Release global mutex
+    - Get thread mutex
+    - Assign job to the thread
+    - Wake up that threads
+    - Release Thread mutex
+    - Abort the loop
+  - else if job_free_list is not empty:
+    - Pick an waiting_job list element out of the free list
+    - Set the job in the element
+    - push the element at the end of waiting_job list
+    - Release global mutex
+    - Abort the loop
+  - else:
+    - Release global mutex
+    - if current time > last warning time + warning_delay
+       - Log a warning about working thread exhausted and waiting queue full
+       - set last warning time to current time
+    - Sleep 20 ms
+    - Get global mutex
+
+The listener threads while waiting on new work:
+
+- Get the thread mutex
+- Loop forever:
+    - if conn is provided in the thread context
+       - Fill the pblock with conn, op
+       - Reset conn in thread context
+       - Release the thread mutex
+       - return CONN_FOUND_WORK_TO_DO
+    - if thread shutdown flag is set:
+       - Release the thread mutex
+       - return CONN_SHUTDOWN
+    - Release the thread mutex
+    - Get the global mutex
+    - If waiting_job queue is empty
+       - Unlink thread from busy threads list
+       - Link thread at start of waiting threads list
+       - Release the global mutex
+       - Get the thread mutex
+       - Wait on the thread condition variable
+       - Loop again
+     - Move first job from waiting_job list to the job_free_list list
+       (after storing the conn in a local variable)
+     - Release the global mutex
+     - Fill the pblock with conn, op
+     - return CONN_FOUND_WORK_TO_DO
+
+### Dynamic change of the number of threads
+
+When changing the number threads:
+
+- if adding threads:
+  - Get global mutex
+  - Compute first new thread index:
+      (size of working_thread list + size of busy_thread list) +1
+  - For each missing threads:
+    - Alloc the thread context struct
+    - Init its mutex and condition variable
+    - Store the thread index in context then increment it
+    - Create the thread (as joinable)
+    - Store the thread id in the context
+  - Release the global mutex
+- else if removing threads:
+  - create a local empty "closing" list
+  - Walk waiting_threads list:
+    - if thread index is higher than wanted number of thread
+      - Move thread from waiting_threads list to closing list
+  - Walk busy_threads list:
+    - if thread index is higher than wanted number of thread
+      - Move thread from busy_threads list to closing list
+  - Release the global mutex
+  - Walk closing list:
+    - Get thread mutex
+    - Set thread closing flags
+    - Wake up the thread
+    - Release thread mutex
+  - Walk closing list:
+    - Join the thread
+    - Unlink thread from closing list
+    - Free thread context
+
+### Monitoring
+
+The following data should be displayed:
+
+| Data                        | Attribute name | Description                                                   |
+| --------------------------- | -------------- | ------------------------------------------------------------- |
+| waiting_thread size         | waitingthreads | Number of worker threads that are waiting for jobs            |
+| busy_thread size            | busythreads    | Number of worker threads that are processing on  jobs         |
+| busy_thread high water mark | maxbusythreads | Highest number of worker threads that are processing on  jobs |
+| waiting_job size            | waitingjobs    | Size of the waiting job queue                                 |
+| waiting_job high water mark | maxwaitingjobs | Highest size of the waiting job queue                         |
+
+
+### Test
+
+An automatic test can be done with the following steps:
+
+- create an instance
+- get the monitoring results
+- check that waitingthreads+busythreads == configured number of threads
+- run pstack of server and check that number of connection_threadmain is the expected one 
+- increase the number of threads
+- check that waitingthreads+busythreads == configured number of threads
+- run pstack of server and check that number of connection_threadmain is the expected one
+- decrease the number of threads
+- check that waitingthreads+busythreads == configured number of threads
+- run pstack of server and check that number of connection_threadmain is the expected one
+
+### Considered Alternatives
+
+- improving old worker thread algorithm to be able to change the number of threads dynamically. (Rejected because a prototype showed that on my laptop, when using trivial jobs that atommically increment a counter, the proposed algorithm was 6 time faster than the older)
+- Adjusting automatically the number of threads to the load. (Rejected because an hard limit is still needed to limit the resource use if an operation blocks the server for some time - and with the new algorithm useless configured threads should not have a noticeable impact (except on the virtual memory footprint)
+- while pushing job in waiting_job queue:
+  - Do not limit list size (Rejected because of the risk of exhausting 
+     the system resources)
+  - alloc job list element (while keeping the global lock or use pre-alloced elements as in current code). Rationnal: This queuing occurs when incomming job load is higher that what the working threads can handle, so the priority is to let the worker threads picks new job as fast as possible and we can slow the listening threads.
+- Using NSPR thread / mutex / condvar or using pthreads
+
+---------------------------------
+
+## Detailed Design
+
+### Functions
+
+#### List handling (inline functions):
+
+| Prototype                                         | Description                          |
+| ------------------------------------------------- | ------------------------------------ |
+| void ll_init(llist_t *elmt, void *data)           | initialize a list element            |
+| void ll_link_before(llist_t *list, llist_t *elmt) | insert an element before current one |
+| void ll_link_after(llist_t *list, llist_t *elmt)  | insert an element after current one  |
+| void ll_unlink(llist_t *elmt)                     | remove an element from the list      |
+
+#### connection_wait_for_new_work
+
+connection_wait_for_new_work(Slapi_PBlock *pb, pc_tinfo_t *tinfo)
+
+This function handles part of the "consumer" side of the algorithm
+ it read the job from the tinfo "conn" field or from the waiting_job queue or wait until condition variable is waken up. 
+
+#### add_work_q
+
+static void
+add_work_q(work_q_item *wqitem, struct Slapi_op_stack *op_stack_obj)
+
+This function handles the "producer" side of the algorithm 
+
+#### init_op_threads
+
+static void init_op_threads()
+
+Initialize the producers/consumers algorithm
+
+#### op_thread_cleanup
+
+void op_thread_cleanup()
+
+Starts the producers/consumers shutdown procedure 
+
+#### connection_post_shutdown_cleanup
+
+void connection_post_shutdown_cleanup()
+
+Free the producers/consumers algorithm resources
+
+#### op_thread_set_threads_number
+
+static void op_thread_set_threads_number(int threadsnumber)
+
+Change the threads number
+
+#### op_thread_get_stat
+
+static void op_thread_get_stat(op_thread_stats_t *st)
+
+Gather the thread statistics
+
+### Data
+
+#### Lists:
+
+All the lists are doubly linked with a guard element as list head.
+allowing for fast item addition in head or tail of the queue and fast removal of an item 
+Two statistics are associated with the list head: 
+
+- the list size
+- the list high water mark (i.e the maximum value of the list size)
+  Access to the lists are protected by the global mutex
+  ( with the exception to the "closing" list that is handled locally (i.e in a single thread) and is not protected. )
+
+##### List element: ll_list_t
+
+| Field | Usage                                                                                                                 |
+| ----- | --------------------------------------------------------------------------------------------------------------------- |
+| next  | next item in the list                                                                                                 |
+| prev  | previous item in the list                                                                                             |
+| data  | the data associated with the item (thread context for list handling threads and the operation for list handling jobs) |
+
+##### List head: ll_head_t
+
+There is one ImportCtx struct per ImportJob and it contains
+the global data needed to perform the import over mdb
+
+| Field | Usage                                                      |
+| ----- | ---------------------------------------------------------- |
+| h     | The guarding element on which are linked the list elements |
+| size  | The list size                                              |
+| hwm   | The list high water mark                                   |
+
+#### Producers/Consumers data: pc_t
+
+This is a static variable "pc" in connection.c 
+
+| Field           | Usage                    |
+| --------------- | ------------------------ |
+| mutex           | The global mutex         |
+| waiting_threads | The waiting threads list |
+| busy_threads    | The busy threads list    |
+| waiting_jobs    | The work queue           |
+| shutdown        | Shutdown in progress     |
+
+#### Thread context data: tinfo_t
+
+This is the per thread context provided as argument when the thread is created
+
+| Field    | Usage                                                          |
+| -------- | -------------------------------------------------------------- |
+| q        | the queue element for that thread (data is the thread context) |
+| mutex    | The per thread mutex                                           |
+| cv       | The per thread cv                                              |
+| conn     | The work to process                                            |
+| shutdown | The flag telling to stop the thread                            |
+| idx      | The thread index (used for smnp and thread removal)            |
+| tid      | The thread id (to join the thread for thread removal           |
+
+#### Statistics data: op_thread_stats_t
+
+| Field          | Usage                                                         |
+| -------------- | ------------------------------------------------------------- |
+| waitingthreads | Number of worker threads that are waiting for jobs            |
+| busythreads    | Number of worker threads that are processing on  jobs         |
+| maxbusythreads | Highest number of worker threads that are processing on  jobs |
+| waitingjobs    | Size of the waiting job queue                                 |
+| maxwaitingjobs | Highest size of the waiting job queue                         |


### PR DESCRIPTION
New design for ldap operation worker threads that:

Allow to change the number of threads without having to restart the server
Reduce the impact of waiting threads (worker threads are only awaken when that thread has something to do.)

Note: this PR was recreated after the wiki repository transfer.
Original review comments are in [wiki389 PR 90](https://github.com/389ds/389wiki/pull/90)  

Reviewed by: @tbordaz 